### PR TITLE
Add support for older Gson versions in SpigotAdapter

### DIFF
--- a/adapter-bukkit/src/main/java/net/kyori/text/adapter/bukkit/CraftBukkitAdapter.java
+++ b/adapter-bukkit/src/main/java/net/kyori/text/adapter/bukkit/CraftBukkitAdapter.java
@@ -78,7 +78,7 @@ final class CraftBukkitAdapter implements Adapter {
         .min(Comparator.comparing(Method::getName)) // prefer the #a method
         .orElseThrow(() -> new RuntimeException("Unable to find serialize method"));
       return new AliveBinding(getHandleMethod, playerConnectionField, sendPacketMethod, chatPacketConstructor, serializeMethod);
-    } catch(final Exception e) {
+    } catch(final Throwable e) {
       return new DeadBinding();
     }
   }


### PR DESCRIPTION
fixes:

```
[14:09:52 INFO]: Luck issued server command: /lp help
[14:09:52 ERROR]: [LuckPerms] Exception whilst executing command: [help]
[14:09:52 WARN]: java.lang.NoClassDefFoundError: com/google/gson/internal/bind/TreeTypeAdapter
[14:09:52 WARN]:        at me.lucko.luckperms.lib.text.adapter.bukkit.SpigotAdapter.bind(SpigotAdapter.java:60)
[14:09:52 WARN]:        at me.lucko.luckperms.lib.text.adapter.bukkit.SpigotAdapter.<clinit>(SpigotAdapter.java:47)
[14:09:52 WARN]:        at me.lucko.luckperms.lib.text.adapter.bukkit.TextAdapter0.pickAdapters(TextAdapter.java:69)
[14:09:52 WARN]:        at me.lucko.luckperms.lib.text.adapter.bukkit.TextAdapter0.<clinit>(TextAdapter.java:64)
[14:09:52 WARN]:        at me.lucko.luckperms.lib.text.adapter.bukkit.TextAdapter.sendComponent(TextAdapter.java:59)
[14:09:52 WARN]:        at me.lucko.luckperms.lib.text.adapter.bukkit.TextAdapter.sendComponent(TextAdapter.java:49)
[14:09:52 WARN]:        at me.lucko.luckperms.bukkit.BukkitSenderFactory.sendMessage(BukkitSenderFactory.java:82)
[14:09:52 WARN]:        at me.lucko.luckperms.bukkit.BukkitSenderFactory.sendMessage(BukkitSenderFactory.java:45)
[14:09:52 WARN]:        at me.lucko.luckperms.common.sender.AbstractSender.sendMessage(AbstractSender.java:104)
[14:09:52 WARN]:        at me.lucko.luckperms.common.command.CommandManager.lambda$sendCommandUsage$12(CommandManager.java:293)
[14:09:52 WARN]:        at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source)
[14:09:52 WARN]:        at java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
[14:09:52 WARN]:        at java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
[14:09:52 WARN]:        at java.util.Iterator.forEachRemaining(Unknown Source)
[14:09:52 WARN]:        at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Unknown Source)
[14:09:52 WARN]:        at java.util.stream.AbstractPipeline.copyInto(Unknown Source)
[14:09:52 WARN]:        at java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
[14:09:52 WARN]:        at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)
[14:09:52 WARN]:        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)
[14:09:52 WARN]:        at java.util.stream.AbstractPipeline.evaluate(Unknown Source)
[14:09:52 WARN]:        at java.util.stream.ReferencePipeline.forEach(Unknown Source)
[14:09:52 WARN]:        at me.lucko.luckperms.common.command.CommandManager.sendCommandUsage(CommandManager.java:278)
[14:09:52 WARN]:        at me.lucko.luckperms.common.command.CommandManager.execute(CommandManager.java:193)
[14:09:52 WARN]:        at me.lucko.luckperms.common.command.CommandManager.lambda$onCommand$0(CommandManager.java:150)
[14:09:52 WARN]:        at java.util.concurrent.CompletableFuture$AsyncSupply.run(Unknown Source)
[14:09:52 WARN]:        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
[14:09:52 WARN]:        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
[14:09:52 WARN]:        at java.lang.Thread.run(Unknown Source)
[14:09:52 WARN]: Caused by: java.lang.ClassNotFoundException: com.google.gson.internal.bind.TreeTypeAdapter
[14:09:52 WARN]:        at java.net.URLClassLoader.findClass(Unknown Source)
[14:09:52 WARN]:        at org.bukkit.plugin.java.PluginClassLoader.findClass(PluginClassLoader.java:101)
[14:09:52 WARN]:        at org.bukkit.plugin.java.PluginClassLoader.findClass(PluginClassLoader.java:86)
[14:09:52 WARN]:        at java.lang.ClassLoader.loadClass(Unknown Source)
[14:09:52 WARN]:        at java.lang.ClassLoader.loadClass(Unknown Source)
[14:09:52 WARN]:        ... 28 more
>
```

https://github.com/lucko/LuckPerms/issues/1344