### PR TITLE
Implement #toLegacyText for sending components to the BungeeCord console

### DIFF
--- a/adapter-bungeecord/src/main/java/net/kyori/text/adapter/bungeecord/TextAdapter.java
+++ b/adapter-bungeecord/src/main/java/net/kyori/text/adapter/bungeecord/TextAdapter.java
@@ -113,8 +113,8 @@ final class TextAdapter0 {
       this.component = component;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
+    @SuppressWarnings("deprecation")
     public String toLegacyText() {
       return ComponentSerializers.LEGACY.serialize(this.component);
     }

--- a/adapter-bungeecord/src/main/java/net/kyori/text/adapter/bungeecord/TextAdapter.java
+++ b/adapter-bungeecord/src/main/java/net/kyori/text/adapter/bungeecord/TextAdapter.java
@@ -113,6 +113,12 @@ final class TextAdapter0 {
       this.component = component;
     }
 
+    @SuppressWarnings("deprecation")
+    @Override
+    public String toLegacyText() {
+      return ComponentSerializers.LEGACY.serialize(this.component);
+    }
+
     @Override
     public BaseComponent duplicate() {
       return this;


### PR DESCRIPTION
Fixes https://github.com/lucko/LuckPerms/issues/1362


An alternative would be to change the adapter to only accept `ProxiedPlayer` parameters.